### PR TITLE
Improve arbiter performance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,11 @@ jobs:
           ./apply_patches.sh digital-lib
           CXX=g++-13 fusesoc --cores-root . run --setup --build --build-root build --target sim --tool verilator socet:chiplet:endpoint
           CXX=g++-13 fusesoc --cores-root . run --setup --build --build-root build --target correctness --tool verilator socet:chiplet:switch
+          CXX=g++-13 fusesoc --cores-root . run --setup --build --build-root build --target arbiter --tool verilator socet:chiplet:switch
           CXX=g++-13 fusesoc --cores-root . run --setup --build --build-root build --target sim --tool verilator socet:chiplet:tile
       - name: Run tests
         run: |
           ./build/socet_chiplet_endpoint_0.0.1/sim-verilator/Vswitch_endpoint_wrapper
           ./build/socet_chiplet_switch_0.0.1/correctness-verilator/Vswitch_wrapper
+          ./build/socet_chiplet_switch_0.0.1/arbiter-verilator/Vswitch_arbiter_wrapper
           ./build/socet_chiplet_tile_1.0.0/sim-verilator/Vtile_wrapper

--- a/switch/source/switch_arbiter.sv
+++ b/switch/source/switch_arbiter.sv
@@ -61,5 +61,9 @@ module switch_arbiter#(
                 found = 1;
             end
         end
+
+        if (a_if.valid && a_if.select == next_select) begin
+            found = 0;
+        end
     end
 endmodule

--- a/switch/source/switch_arbiter.sv
+++ b/switch/source/switch_arbiter.sv
@@ -38,30 +38,27 @@ module switch_arbiter#(
         left &= a_if.bid;
         right &= a_if.bid;
 
-        // Current winner has finished request
-        if (!a_if.valid) begin
-            // Start looking at everything after current requester to find
-            // first set
-            for (int i = 0; i < WIDTH; i++) begin
-                if (!found && right[i]) begin
-                    /* verilator lint_off WIDTHTRUNC */
-                    next_select = i;
-                    next_flit = a_if.rdata[next_select];
-                    /* verilator lint_on WIDTHTRUNC */
-                    found = 1;
-                end
+        // Start looking at everything after current requester to find
+        // first set
+        for (int i = 0; i < WIDTH; i++) begin
+            if (!found && right[i]) begin
+                /* verilator lint_off WIDTHTRUNC */
+                next_select = i;
+                next_flit = a_if.rdata[next_select];
+                /* verilator lint_on WIDTHTRUNC */
+                found = 1;
             end
+        end
 
-            // Then look for anything to the left (including current
-            // selection)
-            for (int i = 0; i < WIDTH; i++) begin
-                if (!found && left[i]) begin
-                    /* verilator lint_off WIDTHTRUNC */
-                    next_select = i;
-                    next_flit = a_if.rdata[next_select];
-                    /* verilator lint_on WIDTHTRUNC */
-                    found = 1;
-                end
+        // Then look for anything to the left (including current
+        // selection)
+        for (int i = 0; i < WIDTH; i++) begin
+            if (!found && left[i]) begin
+                /* verilator lint_off WIDTHTRUNC */
+                next_select = i;
+                next_flit = a_if.rdata[next_select];
+                /* verilator lint_on WIDTHTRUNC */
+                found = 1;
             end
         end
     end

--- a/switch/switch.core
+++ b/switch/switch.core
@@ -63,6 +63,12 @@ filesets:
             - "testbench/tb_switch_correctness.cc": {file_type: cppSource}
         file_type: systemVerilogSource
 
+    arbiter_tb:
+        files:
+            - "testbench/switch_arbiter_wrapper.sv"
+            - "testbench/tb_switch_arbiter.cc": {file_type: cppSource}
+        file_type: systemVerilogSource
+
     fpga:
         files:
             - "fpga/fpga_switch_wrapper.sv"
@@ -151,6 +157,28 @@ targets:
                     - --trace
                     - --trace-structs
                     - --main
+                    - --timing
+                    - --coverage
+                    - -Wno-WIDTHEXPAND
+                    - -Wno-TIMESCALEMOD
+                    - -CFLAGS -std=c++20
+                    - -trace-fst
+                make_options:
+                    - -j
+
+    arbiter:
+        <<: *default
+        default_tool: verilator
+        filesets_append:
+            - arbiter_tb
+        toplevel:
+            - "tool_verilator? (switch_arbiter_wrapper)"
+        tools:
+            verilator:
+                verilator_options:
+                    - --cc
+                    - --trace
+                    - --trace-structs
                     - --timing
                     - --coverage
                     - -Wno-WIDTHEXPAND

--- a/switch/testbench/switch_arbiter_wrapper.sv
+++ b/switch/testbench/switch_arbiter_wrapper.sv
@@ -1,0 +1,20 @@
+module switch_arbiter_wrapper(
+    input logic CLK, nRST,
+    input logic [7:0] bid,
+    output logic valid,
+    output logic [2:0] select
+);
+    arbiter_if #(.WIDTH(8)) arbiter_if();
+    switch_arbiter #(
+        .WIDTH(8)
+    ) arbiter (
+        .CLK(CLK),
+        .nRST(nRST),
+        .a_if(arbiter_if)
+    );
+
+    assign arbiter_if.bid = bid;
+    assign arbiter_if.rdata = 0;
+    assign valid = arbiter_if.valid;
+    assign select = arbiter_if.select;
+endmodule

--- a/switch/testbench/tb_switch_arbiter.cc
+++ b/switch/testbench/tb_switch_arbiter.cc
@@ -1,0 +1,144 @@
+#include "Vswitch_arbiter_wrapper.h"
+#include "verilated.h"
+#include "verilated_fst_c.h"
+
+uint64_t sim_time = 0;
+uint64_t fails = 0;
+
+Vswitch_arbiter_wrapper *dut;
+VerilatedFstC *trace;
+
+void signalHandler(int signum) {
+    std::cout << "Got signal " << signum << std::endl;
+    std::cout << "Calling SystemVerilog 'final' block & exiting!" << std::endl;
+
+    dut->final();
+    trace->close();
+
+    exit(signum);
+}
+
+void tick(bool limit) {
+    dut->CLK = 0;
+    dut->eval();
+    trace->dump(sim_time++);
+    dut->CLK = 1;
+    dut->eval();
+    trace->dump(sim_time++);
+
+    if (limit && sim_time > 1000000) {
+        signalHandler(0);
+    }
+}
+
+void reset() {
+    dut->CLK = 0;
+    dut->nRST = 1;
+    dut->bid = 0;
+
+    tick(false);
+    dut->nRST = 0;
+    tick(false);
+    tick(false);
+    tick(false);
+    dut->nRST = 1;
+    tick(false);
+    tick(false);
+}
+
+void wait_for_propagate(uint32_t waits) {
+    for (int i = 0; i < waits; i++) {
+        tick(false);
+    }
+}
+
+void ensure(uint8_t actual, uint8_t expected, const char *test_name) {
+    if (actual != expected) {
+        printf("[FAIL] Time %d\t%s actual: %d, expected: %d\n", sim_time, test_name, actual,
+               expected);
+        fails++;
+    }
+}
+
+int main(int argc, char **argv) {
+    dut = new Vswitch_arbiter_wrapper;
+    trace = new VerilatedFstC;
+    Verilated::traceEverOn(true);
+    dut->trace(trace, 5);
+    trace->open("arbiter.fst");
+
+    // Test case 1: single bid
+    {
+        reset();
+        dut->bid = 0x10;
+        ensure(dut->select, 0, "test case 1 before tick");
+        ensure(dut->valid, 0, "test case 1 before tick");
+        tick(false);
+        ensure(dut->select, 4, "test case 1 after tick");
+        ensure(dut->valid, 1, "test case 1 after tick");
+    }
+
+    // Test case 2: multi bid
+    {
+        reset();
+        dut->bid = 0x11;
+        ensure(dut->select, 0, "test case 2 before tick");
+        ensure(dut->valid, 0, "test case 2 before tick");
+        tick(false);
+        ensure(dut->select, 4, "test case 2 after tick");
+        ensure(dut->valid, 1, "test case 2 after tick");
+    }
+
+    // Test case 3: multi bid, multi cycle, go left
+    {
+        reset();
+        dut->bid = 0x11;
+        ensure(dut->select, 0, "test case 3 before tick");
+        tick(false);
+        ensure(dut->select, 4, "test case 3 after tick");
+        ensure(dut->valid, 1, "test case 3 after tick");
+        tick(false);
+        ensure(dut->select, 0, "test case 3 after second tick");
+        ensure(dut->valid, 1, "test case 3 after second tick");
+    }
+
+    // Test case 4: multi bid, multi cycle, go right
+    {
+        reset();
+        dut->bid = 0x10;
+        ensure(dut->select, 0, "test case 4 before tick");
+        tick(false);
+        ensure(dut->select, 4, "test case 4 after tick");
+        ensure(dut->valid, 1, "test case 4 after tick");
+        dut->bid |= 1 << 7;
+        tick(false);
+        ensure(dut->select, 7, "test case 4 after second tick");
+        ensure(dut->valid, 1, "test case 4 after second tick");
+    }
+
+    // Test case 5: single bid, multi cycle, go self
+    {
+        reset();
+        dut->bid = 0x10;
+        ensure(dut->select, 0, "test case 4 before tick");
+        tick(false);
+        ensure(dut->select, 4, "test case 4 after tick");
+        ensure(dut->valid, 1, "test case 4 after tick");
+        tick(false);
+        ensure(dut->select, 4, "test case 4 after second tick");
+        ensure(dut->valid, 1, "test case 4 after second tick");
+    }
+
+    wait_for_propagate(10);
+
+    if (fails != 0) {
+        std::cout << "\x1b[31mTotal failures\x1b[0m: " << fails << std::endl;
+    } else {
+        std::cout << "\x1b[32mALL TESTS PASSED\x1b[0m" << std::endl;
+    }
+
+    dut->final();
+    trace->close();
+
+    return fails;
+}

--- a/switch/testbench/tb_switch_arbiter.cc
+++ b/switch/testbench/tb_switch_arbiter.cc
@@ -125,8 +125,10 @@ int main(int argc, char **argv) {
         ensure(dut->select, 4, "test case 4 after tick");
         ensure(dut->valid, 1, "test case 4 after tick");
         tick(false);
-        ensure(dut->select, 4, "test case 4 after second tick");
-        ensure(dut->valid, 1, "test case 4 after second tick");
+        ensure(dut->valid, 0, "test case 4 after second tick");
+        tick(false);
+        ensure(dut->select, 4, "test case 4 after third tick");
+        ensure(dut->valid, 1, "test case 4 after third tick");
     }
 
     wait_for_propagate(10);


### PR DESCRIPTION
Previously, the arbiter would select bid lines on a "tick-tock" cadence, even if there are multiple bid lines active. This PR fixes that so that each line can be selected one after the other unless it is the currently selected line. 